### PR TITLE
refactor: standardize code style and module documentation

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1,7 +1,8 @@
-//! HTTP 요청 핸들러 모듈.
+//! HTTP request handler module.
 
 use std::borrow::Cow;
 
+use askama::Template;
 use axum::{
     extract::{Path, State},
     http::header,
@@ -21,8 +22,6 @@ use crate::config::APP_CONFIG;
 use crate::error::{AppError, AppResult, ValidationErrorExt};
 use crate::models::{CreateOrFindResult, NewUrl, UrlCacheData, UrlRepository};
 use crate::utils::{gen_rand_str, gen_token, merge_short_key, split_short_key};
-
-use askama::Template;
 
 /// Index page template.
 #[derive(Template)]

--- a/src/api/middlewares.rs
+++ b/src/api/middlewares.rs
@@ -1,4 +1,6 @@
-//! 미들웨어 모듈.
+//! Middleware module.
+//!
+//! Provides authentication and other request processing middleware.
 
 use axum::{body::Body, extract::Request, http::header, middleware::Next, response::Response};
 use axum_extra::extract::CookieJar;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,6 @@
-//! API 모듈.
+//! API module.
+//!
+//! Contains HTTP handlers, routes, schemas, and middleware.
 
 pub mod handlers;
 pub mod middlewares;

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1,4 +1,6 @@
-//! 라우트 설정 모듈.
+//! Route configuration module.
+//!
+//! Defines all HTTP routes and their middleware stack.
 
 use axum::{
     middleware,

--- a/src/api/schemas.rs
+++ b/src/api/schemas.rs
@@ -1,8 +1,11 @@
-//! 요청/응답 스키마 모듈.
+//! Request/response schema module.
+//!
+//! Contains DTOs for API request validation and response serialization.
 
-use crate::error::AppError;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
+
+use crate::error::AppError;
 
 /// Short URL creation request structure.
 ///

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1,4 +1,6 @@
-//! 애플리케이션 상태 모듈.
+//! Application state module.
+//!
+//! Contains shared state for database and cache connections.
 
 use deadpool_redis::Pool as RedisPool;
 use sqlx::PgPool;

--- a/src/config/cache.rs
+++ b/src/config/cache.rs
@@ -1,9 +1,12 @@
-//! Redis 캐시 설정 모듈.
+//! Redis cache configuration module.
+//!
+//! Provides Redis connection pool initialization and management.
+
+use deadpool_redis::{Config, Pool, PoolConfig, Runtime};
+use once_cell::sync::OnceCell;
 
 use crate::config::env::{get_env, APP_CONFIG};
 use crate::error::AppResult;
-use deadpool_redis::{Config, Pool, PoolConfig, Runtime};
-use once_cell::sync::OnceCell;
 
 static CACHE_POOL: OnceCell<Pool> = OnceCell::new();
 

--- a/src/config/db.rs
+++ b/src/config/db.rs
@@ -1,11 +1,15 @@
-//! 데이터베이스 설정 모듈.
+//! Database configuration module.
+//!
+//! Provides `PostgreSQL` connection pool initialization and management.
 
-use crate::config::env::{get_env, APP_CONFIG};
-use crate::error::AppResult;
+use std::time::Duration;
+
 use once_cell::sync::OnceCell;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
-use std::time::Duration;
+
+use crate::config::env::{get_env, APP_CONFIG};
+use crate::error::AppResult;
 
 static DB_POOL: OnceCell<PgPool> = OnceCell::new();
 

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,8 +1,11 @@
-//! 환경 변수 설정 모듈.
+//! Environment variable configuration module.
+//!
+//! Provides environment variable loading and the global `APP_CONFIG` instance.
 
-use once_cell::sync::Lazy;
 use std::env;
 use std::sync::Once;
+
+use once_cell::sync::Lazy;
 
 static INIT: Once = Once::new();
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,6 @@
-//! 설정 모듈.
+//! Configuration module.
+//!
+//! Contains environment configuration, database, and cache pool initialization.
 
 pub mod cache;
 pub mod db;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
-//! 중앙화된 에러 처리 모듈.
+//! Centralized error handling module.
+//!
+//! This module defines the `AppError` enum and `AppResult` type alias
+//! used throughout the application for consistent error handling.
 
 use axum::{
     http::StatusCode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! URL 단축 서비스 라이브러리.
+//! URL shortening service library.
 
 pub mod api;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! URL 단축 서비스 진입점.
+//! URL shortening service entry point.
 
 mod api;
 mod config;
@@ -14,9 +14,7 @@ use tokio::signal;
 use tower_governor::{
     governor::GovernorConfigBuilder, key_extractor::SmartIpKeyExtractor, GovernorLayer,
 };
-use tower_http::compression::CompressionLayer;
-use tower_http::cors::CorsLayer;
-use tower_http::trace::TraceLayer;
+use tower_http::{compression::CompressionLayer, cors::CorsLayer, trace::TraceLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::api::{create_routes, AppState};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,6 @@
-//! 모델 모듈.
+//! Model module.
+//!
+//! Contains domain entities and repository pattern for data access.
 
 pub mod url;
 

--- a/src/models/url.rs
+++ b/src/models/url.rs
@@ -1,4 +1,6 @@
-//! URL 모델 모듈.
+//! URL model module.
+//!
+//! Contains URL entity, cache data, and repository for database operations.
 
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -1,4 +1,6 @@
-//! JWT 유틸리티 모듈.
+//! JWT utility module.
+//!
+//! Provides JWT token generation and parsing functions.
 
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use once_cell::sync::Lazy;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,6 @@
-//! 유틸리티 모듈.
+//! Utility module.
+//!
+//! Provides JWT, random string generation, and short key encoding utilities.
 
 pub mod jwt;
 pub mod rand;

--- a/src/utils/rand.rs
+++ b/src/utils/rand.rs
@@ -1,4 +1,6 @@
-//! 랜덤 문자열 생성 모듈.
+//! Random string generation module.
+//!
+//! Provides secure random alphanumeric string generation.
 
 use rand::distributions::{Alphanumeric, DistString};
 

--- a/src/utils/short_key.rs
+++ b/src/utils/short_key.rs
@@ -1,4 +1,6 @@
-//! 단축키 인코딩/디코딩 모듈.
+//! Short key encoding/decoding module.
+//!
+//! Provides Base62 encoding for collision-free short URL key generation.
 
 /// Length of the random prefix (first part of short key).
 pub const RAND_PREFIX_LEN: usize = 2;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,6 @@
-//! 통합 테스트 모듈.
+//! Integration test module.
+//!
+//! Contains end-to-end tests for the URL shortening service.
 
 use url_shortener::api::schemas::{
     validate_short_key, CreateShortUrlRequest, CreateShortUrlResponse,


### PR DESCRIPTION
- Convert all module-level documentation from Korean to English
- Standardize import order (std -> external crates -> internal modules)
- Consolidate tower_http imports in main.rs
- Fix clippy warning for PostgreSQL backticks in doc comment
- Add detailed module descriptions following CLAUDE.md guidelines

All changes follow the code style guidelines in CLAUDE.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to English across modules for improved clarity.

* **Chores**
  * Reorganized configuration and import structure for better code maintainability.
  * Improved module organization and public exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->